### PR TITLE
Adds env vars for endpoint & region

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+awsRegion=us-east-1
+ELASTICSEARCH_ENDPOINT=http://localhost:9200

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.0.0-20191218082911-5398a82b748f
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/gorilla/mux v1.7.3 // indirect
+	github.com/joho/godotenv v1.3.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/sys v0.0.0-20200103143344-a1369afcdac7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAU
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/go-chi/chi"
+	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
 )
 
@@ -20,12 +21,31 @@ type server struct {
 	elasticClient *elasticsearch.Client
 }
 
+type config struct {
+	Region          string
+	ElasticEndpoint string
+}
+
+func main() {
+	handler()
+}
+
 func handler() {
 	logger := logrus.New()
 	logger.SetFormatter(&logrus.JSONFormatter{})
 
+	// Load .env if its present (used for local dev)
+	if err := godotenv.Load(); err != nil {
+		logger.Info("No .env file found.")
+	}
+
+	config := config{
+		Region:          os.Getenv("REGION"),
+		ElasticEndpoint: os.Getenv("ELASTICSEARCH_ENDPOINT"),
+	}
+
 	cfg := elasticsearch.Config{
-		Addresses: []string{"http://localhost:9200"},
+		Addresses: []string{config.ElasticEndpoint},
 		Transport: &http.Transport{
 			Dial: (&net.Dialer{
 				Timeout:   30 * time.Second,
@@ -76,8 +96,4 @@ func handler() {
 		s.logger.Fatal(err.Error())
 	}
 
-}
-
-func main() {
-	handler()
 }


### PR DESCRIPTION

- uses `godotenv` to pull env vars from `.env` file for local dev
- converts Elasticsearch address from a string to env var value
